### PR TITLE
feat(Button-Component): Adding style prop to Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-router": "^3.0.0",
+    "react-style-proptype": "^1.4.0",
     "reactcss": "^1.0.7"
   },
   "devDependencies": {

--- a/specs/components/Button.spec.jsx
+++ b/specs/components/Button.spec.jsx
@@ -39,6 +39,8 @@ describe('Button', function () {
   it('Group Position: Left', () => this.props({ groupPosition: 'left' }));
   it('Group Position: Center', () => this.props({ groupPosition: 'center' }));
   it('Group Position: Right', () => this.props({ groupPosition: 'right' }));
+  it('Sets Styles', () => this.props({ style: { background: 'pink' } }));
+  it('Resets Styles', () => this.props({ style: {} }));
 
   /**
    * Documentation (Markdown)

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,6 +1,7 @@
 import color from 'color';
 import React from 'react';
 import reactCSS from 'reactcss';
+import stylePropType from 'react-style-proptype';
 import Base from './Base';
 
 export default class Button extends Base {
@@ -21,6 +22,7 @@ export default class Button extends Base {
       'danger',
     ]),
     working: React.PropTypes.bool,
+    style: stylePropType,
   };
 
   static defaultProps = {
@@ -160,13 +162,14 @@ export default class Button extends Base {
       groupPositionCenter: this.props.groupPosition === 'center',
       groupPositionRight: this.props.groupPosition === 'right',
     });
+    const buttonStyle = Object.assign({}, style.Button, this.props.style);
     return (
       <button
         disabled={this.props.working || !this.props.enabled}
         onClick={this.props.onClick}
         onMouseOut={this.handleMouseOut.bind(this)}
         onMouseOver={this.handleMouseOver.bind(this)}
-        style={style.Button}
+        style={buttonStyle}
       >
         {this.renderChildren()}
       </button>


### PR DESCRIPTION
Before adding a style prop to the Button Component, we were unable to override the default styling

of this component. We can now easily override and insert custom styling