### PR TITLE
refactor(Table-component): Refactor onChange event handler

### DIFF
--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -148,19 +148,13 @@ export default class Table extends Base {
   }
 
   handleSelectAll() {
-    const processedRecords = this.processRecords(this.props.selectedRows);
-    const selectedRows = [...Array(processedRecords.length).keys()];
-    this.props.onChange(selectedRows);
+    this.props.onChange(this.processRecords());
   }
 
-  handleRowSelect(columnKey, xCord, cellData, row, yCord) {
-    this.props.onChange({
-      columnKey,
-      xCord,
-      cellData,
-      row,
-      yCord,
-    });
+  handleRowSelect(row, yCord) {
+    const rows = [];
+    rows[yCord] = row;
+    this.props.onChange(rows);
   }
 
   renderHeaderItem(style) {
@@ -177,6 +171,7 @@ export default class Table extends Base {
     const selectAllHeader = (
       <th
         key={0}
+        onClick={this.handleSelectAll.bind(this)}
         style={style.TheadItems}
       >
         <Checkbox
@@ -203,7 +198,7 @@ export default class Table extends Base {
       <td
         key={xCord}
         style={tdStyle}
-        onClick={this.handleRowSelect.bind(this, columnKey, xCord, cellData, row, yCord)}
+        onClick={this.handleRowSelect.bind(this, row, yCord)}
       >
         <Checkbox
           checked={shouldBeChecked}
@@ -277,8 +272,7 @@ export default class Table extends Base {
 
   render() {
     const clr = this.getColors();
-    const sourceRecords = this.props.records;
-    const records = this.processRecords(sourceRecords);
+    const records = this.processRecords();
     const style = reactCSS({
       default: {
         selected: {

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -191,7 +191,7 @@ export default class Table extends Base {
     );
   }
 
-  renderCheckBox(tdStyle, columnKey, xCord, cellData, row, yCord) {
+  renderCheckBox(tdStyle, xCord, row, yCord) {
     this.checkBoxRefs = [];
     const shouldBeChecked = this.props.selectedRows.indexOf(yCord) > -1;
     return (
@@ -229,7 +229,7 @@ export default class Table extends Base {
     const isSelectedRow = rowSelected ? style.selected : undefined;
     const rowStyle = (i === this.state.hoveredRow ? style.TableRow : isSelectedRow);
     const rowItem = Object.keys(row).map((item, ri) => this.renderItems(style, item, ri, row, i));
-    const multiSelectItem = this.renderCheckBox(style.TBodyItems, '', 0, '', row, i);
+    const multiSelectItem = this.renderCheckBox(style.TBodyItems, 0, row, i);
 
     return rowItem.length > 0 ? (
       <tr

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -334,14 +334,10 @@ describe('Table', () => {
       onChange: mockHandleChange,
     });
     const checkBoxNode = tableComponent.checkBoxRefs[2].inputRef;
+    const result = [];
+    result[2] = records[2];
     TestUtils.Simulate.click(checkBoxNode);
-    expect(mockHandleChange).toBeCalledWith({
-      cellData: '',
-      columnKey: '',
-      row: records[2],
-      xCord: 0,
-      yCord: 2,
-    });
+    expect(mockHandleChange).toBeCalledWith(result);
   });
   it('returns a change event when select all is triggered', () => {
     const mockHandleChange = jest.fn();
@@ -353,7 +349,20 @@ describe('Table', () => {
     });
     const checkBoxNode = tableComponent.checkBoxHeaderRef.inputRef;
     TestUtils.Simulate.change(checkBoxNode);
-    expect(mockHandleChange).toBeCalledWith([0, 1, 2, 3, 4]);
+    expect(mockHandleChange).toBeCalledWith(records);
+  });
+
+  it('returns a change event when clicking anywhere within the select all checkbox th cell', () => {
+    const mockHandleChange = jest.fn();
+    renderTable({
+      headers,
+      records,
+      multiSelectable: true,
+      onChange: mockHandleChange,
+    });
+    const selectAllTHNode = headerElement(0);
+    TestUtils.Simulate.click(selectAllTHNode);
+    expect(mockHandleChange).toBeCalledWith(records);
   });
 
   it('returns a change event when filtering segments and select all is triggered', () => {
@@ -370,7 +379,7 @@ describe('Table', () => {
     expect(rows().length).toBe(2);
     expect(cell(0, 1).textContent).toBe('Frank');
     expect(cell(1, 1).textContent).toBe('Jose');
-    expect(mockHandleChange).toBeCalledWith([0, 1]);
+    expect(mockHandleChange).toBeCalledWith([records[1], records[3]]);
   });
 
   it('selects a row when clicking anywhere within the checkbox cell', () => {
@@ -381,14 +390,10 @@ describe('Table', () => {
       multiSelectable: true,
       onChange: mockHandleChange,
     });
+    const result = [];
+    result[0] = records[0];
 
     TestUtils.Simulate.click(cell(0, 0));
-    expect(mockHandleChange).toBeCalledWith({
-      cellData: '',
-      columnKey: '',
-      row: records[0],
-      xCord: 0,
-      yCord: 0,
-    });
+    expect(mockHandleChange).toBeCalledWith(result);
   });
 });


### PR DESCRIPTION
Previously, onChange would return an array on selecting all and an object on selecting an individual

row. This was confusing. Now onChange will return an array for both events.

Any components that use the Table and rely on the onChange prop will need to be updated to handle

this change.