### PR TITLE
fix(component-Table): Border is off for zero state with filter

### DIFF
--- a/specs/components/Table.spec.jsx
+++ b/specs/components/Table.spec.jsx
@@ -167,6 +167,15 @@ describe('Table', function () {
         filterRecords: [{ bar: 'foo' }],
       });
   });
+  it('All records to filtered out with multiselect', () => {
+    this.loadTable(
+      {
+        headers: this.headers,
+        records: this.records,
+        filterRecords: [{ bar: 'foo' }],
+        multiSelectable: true,
+      });
+  });
   it('Sets column width', () => {
     this.loadTable(
       {

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -244,23 +244,16 @@ export default class Table extends Base {
   }
 
   renderNoResults(style) {
-    let colSpan = {};
-    if (this.props.headers) {
-      colSpan = this.props.headers;
-    } else if (this.props.records[0]) {
-      colSpan = this.props.records[0];
-    }
-
-    /* Normally mapped to headers or records,
-    we need to add a dummy element to account for the checkbox column for multiselect */
+    let colSpan = Object.keys(this.processHeaders()).length;
+    /* We need to add an element to account for the checkbox column for multiselect */
     if (this.props.multiSelectable) {
-      colSpan.multiSelectFiller = '';
+      colSpan += 1;
     }
 
     return (
       <tr>
         <td
-          colSpan={Object.keys(colSpan).length}
+          colSpan={colSpan > 0 ? colSpan : 1}
           style={style.TBodyItems}
         >
           {this.props.noRecordsText}

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -244,11 +244,17 @@ export default class Table extends Base {
   }
 
   renderNoResults(style) {
-    let colSpan = '';
+    let colSpan = {};
     if (this.props.headers) {
       colSpan = this.props.headers;
     } else if (this.props.records[0]) {
       colSpan = this.props.records[0];
+    }
+
+    /* Normally mapped to headers or records,
+    we need to add a dummy element to accont for the checkbox column for multiselect */
+    if (this.props.multiSelectable) {
+      colSpan.multiSelectFiller = '';
     }
 
     return (

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -252,7 +252,7 @@ export default class Table extends Base {
     }
 
     /* Normally mapped to headers or records,
-    we need to add a dummy element to accont for the checkbox column for multiselect */
+    we need to add a dummy element to account for the checkbox column for multiselect */
     if (this.props.multiSelectable) {
       colSpan.multiSelectFiller = '';
     }

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -415,4 +415,12 @@ describe('Table', () => {
     });
     expect(cell(0, 0).colSpan).toEqual('4');
   });
+  /* Colspan cannot be 0, so it's important it's always at least 1 for the zerostate */
+  it('generates colSpan for no records and no headers', () => {
+    renderTable({
+      headers: {},
+      records: [],
+    });
+    expect(cell(0, 0).colSpan).toEqual('1');
+  });
 });

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -396,4 +396,23 @@ describe('Table', () => {
     TestUtils.Simulate.click(cell(0, 0));
     expect(mockHandleChange).toBeCalledWith(result);
   });
+
+  it('generates colSpan for no results', () => {
+    renderTable({
+      headers,
+      records,
+      filterRecords: [{ age: 125 }],
+    });
+    expect(cell(0, 0).colSpan).toEqual('3');
+  });
+
+  it('generates colSpan for no results and multiselect', () => {
+    renderTable({
+      headers,
+      records,
+      filterRecords: [{ age: 125 }],
+      multiSelectable: true,
+    });
+    expect(cell(0, 0).colSpan).toEqual('4');
+  });
 });


### PR DESCRIPTION
If mult-select is enabled and zero state visible by using a filter that returns no records, there is

border that doesn't span the entire table. The colSpan was not calculating columns right. It was

missing the first column used for the checkboxes.