### PR TITLE
fix(component-dataTable): Aded the ability to sort non-primitive types.

### DIFF
--- a/specs/components/DataTable.spec.jsx
+++ b/specs/components/DataTable.spec.jsx
@@ -252,6 +252,30 @@ describe('DataTable', function () {
       });
   });
 
+  it('Sorts records with custom getSortValue', () => {
+    const getSortValue = value => (value.props ? value.props.children : value);
+    this.loadTable(
+      {
+        columns: {
+          order: ['name', 'color'],
+        },
+        headers: this.headers,
+        records: [{
+          name: 'Ryan Balla',
+          color: 'Blue',
+        },
+        {
+          name: <a href="http://signal.co">Signal Digital</a>,
+          color: 'Red',
+        }],
+        orderBy: {
+          column: 'name',
+          direction: 'desc',
+          getSortValue,
+        },
+      });
+  });
+
   /**
    * Documentation (Markdown)
    */
@@ -265,9 +289,10 @@ describe('DataTable', function () {
   - **recordInclusion** *PropTypes.object* (optional) maps to key of record, used to limit what is displayed
   - **onClick** *PropTypes.function* (optional) used to take action on clicking, supplies row index, row data and cell data. When defined, a hover effect is applied to the row.
   - **orderBy** *PropTypes.shape* (optional)
-    - **column** *PropTypes.string (optional) column of data to order by
-    - **direction** *PropTypes.oneOf (optional) 'asc' or 'desc'
-    - **formatter** *PropTypes.oneOf (optional) 'date' specify a way to format column data for sorting
+    - **column** *PropTypes.string* (optional) column of data to order by
+    - **direction** *PropTypes.oneOf* (optional) 'asc' or 'desc'
+    - **formatter** *PropTypes.oneOf* (optional) 'date' specify a way to format column data for sorting
+    - **getSortValue** *PropTypes.func* (optional) a function that takes column data and returns a value to be used for sorting, needed for non-primitive data types, like React Components.
   - **selectedRows** *PropTypes.arrayOf(PropTypes.number)* select rows based on index
   - **returnAllRecordsOnClick** *PropTypes.bool* (optional) returns all records for a row in the onClick argument regardless of record inclusion option
   - **filterRecords**  *PropTypes.object* key/ value set of data to filter the records against. If multiple values are supplied, it's considered an OR not an AND

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -29,6 +29,7 @@ export default class DataTable extends Base {
         Use date for any dates, must be pure date (Yes: 10/20/1994 No: Updated: 10/20/1994)
       */
       formatter: PropTypes.oneOf(['date']),
+      getSortValue: PropTypes.func,
     }),
     onClick: PropTypes.func,
     onHeaderClick: PropTypes.func,
@@ -126,12 +127,14 @@ export default class DataTable extends Base {
          +(a < b) || +(a === b) - 1,
     };
 
+    const { getSortValue = value => value } = this.props.orderBy;
+
     return mappedRecords.sort((a, b) => {
       switch (this.props.orderBy.formatter) {
         case 'date':
           return ops[this.props.orderBy.direction](new Date(a.value), new Date(b.value));
         default:
-          return ops[this.props.orderBy.direction](a.value, b.value);
+          return ops[this.props.orderBy.direction](getSortValue(a.value), getSortValue(b.value));
       }
     });
   }

--- a/tests/DataTable.test.jsx
+++ b/tests/DataTable.test.jsx
@@ -70,6 +70,7 @@ let rows;
 let cell;
 
 const mockHandleClick = jest.fn();
+const getSortValue = value => (value.props ? value.props.children : value);
 const renderTable = (props) => {
   tableComponent = ReactTestUtils.renderIntoDocument(
     <DataTable
@@ -587,5 +588,39 @@ describe('Table', () => {
     expect(cell(0, 0).textContent).toBe('2015/12/05 15:06');
     expect(cell(1, 0).textContent).toBe('2016/02/18 17:09');
     expect(cell(2, 0).textContent).toBe('2016/10/18 17:09');
+  });
+
+  it('Sorts records with custom getSortValue ascending', () => {
+    renderTable({
+      headers,
+      records: [
+        { name: <a href="foo.com">Foo</a> },
+        { name: 'Bar' },
+      ],
+      orderBy: {
+        column: 'name',
+        direction: 'asc',
+        getSortValue,
+      },
+    });
+    expect(cell(0, 0).textContent).toContain('Bar');
+    expect(cell(1, 0).textContent).toContain('Foo');
+  });
+
+  it('Sorts records with non-primitive data types using getSortValue', () => {
+    renderTable({
+      headers,
+      records: [
+        { name: <a href="foo.com">Foo</a> },
+        { name: <a href="bar.com">Bar</a> },
+      ],
+      orderBy: {
+        column: 'name',
+        direction: 'desc',
+        getSortValue,
+      },
+    });
+    expect(cell(0, 0).textContent).toContain('Foo');
+    expect(cell(1, 0).textContent).toContain('Bar');
   });
 });


### PR DESCRIPTION
Added a new optional prop, getSortValue, that takes the column data and return the value to be used in sorting.

Issue #24