### PR TITLE
fix(Component-DataTable): use a user provided column for identifying selected rows

### DIFF
--- a/specs/components/DataTable.spec.jsx
+++ b/specs/components/DataTable.spec.jsx
@@ -46,43 +46,26 @@ describe('DataTable', function () {
   ## DataTable
   `); // Markdown.
 
+  const handleClick = (column, xCord, cellData, rowData, yCord) => {
+    console.log({
+      Column: column,
+      xCord,
+      'Cell Data': cellData,
+      'Row Data': rowData,
+      yCord,
+    });
+  };
   this.loadTable = (props) => {
-    const handleClick = (column, xCord, cellData, rowData, yCord) => {
-      console.log({
-        Column: column,
-        xCord,
-        'Cell Data': cellData,
-        'Row Data': rowData,
-        yCord,
-      });
-    };
     this.unload();
     this.component(
       <DataTable
-        columns={props.columns}
-        headers={props.headers}
-        filterRecords={props.filterRecords}
-        onClick={handleClick}
-        orderBy={props.orderBy}
-        records={
-          props.records
-        }
-        recordInclusion={props.recordInclusion}
-        selectedRows={props.selectedRows}
-        multiSelectable={props.multiSelectable}
-        onChange={props.onChange}
+        {...props}
       />,
     );
   };
 
   before(() => {
-    // Runs when the Suite loads.  Use this to host your component-under-test.
-    this.loadTable({
-      headers: this.headers,
-      records: this.records,
-      recordInclusion: this.recordInclusion,
-      filterRecords: this.filterRecords,
-    });
+    this.unload();
   });
 
   it('Has no records', () => {
@@ -97,18 +80,20 @@ describe('DataTable', function () {
     this.loadTable(
       {
         headers: this.headers,
+        multiSelectColumnName: 'name',
         records: this.records,
         recordInclusion: this.recordInclusion,
-        selectedRows: [row],
+        selectedRows: [this.records[row].name],
       });
   });
   it('Select multiple rows', () => {
     this.loadTable(
       {
         headers: this.headers,
+        multiSelectColumnName: 'name',
         records: this.records,
         recordInclusion: this.recordInclusion,
-        selectedRows: [2, 3],
+        selectedRows: [this.records[2].name, this.records[3].name],
       });
   });
   it('Exclude Age', () => {
@@ -132,7 +117,6 @@ describe('DataTable', function () {
       {
         headers: this.headers,
         records: this.records,
-        onClick: null,
       });
   });
   it('Add click handler', () => {
@@ -140,7 +124,7 @@ describe('DataTable', function () {
       {
         headers: this.headers,
         records: this.records,
-        onClick: true,
+        onClick: handleClick,
       });
   });
   it('Filters records', () => {
@@ -174,7 +158,7 @@ describe('DataTable', function () {
         headers: this.headers,
         records: this.records,
         filterRecords: [{ bar: 'foo' }],
-        multiSelectable: true,
+        multiSelectColumnName: 'name',
       });
   });
   it('Sets column width', () => {
@@ -206,7 +190,7 @@ describe('DataTable', function () {
         },
         headers: this.headers,
         records: this.records,
-        multiSelectable: true,
+        multiSelectColumnName: 'name',
         onChange: () => { console.log('Table changed'); },
       });
   });
@@ -223,7 +207,7 @@ describe('DataTable', function () {
           color: 'Blue',
           age: 100,
         }],
-        multiSelectable: true,
+        multiSelectColumnName: 'name',
         onChange: () => { console.log('Table changed'); },
       });
   });
@@ -286,6 +270,7 @@ describe('DataTable', function () {
     - **width** *PropTypes.array* (optional) sets the width of individual columns the value specified here. If a column is obmitted 'auto' is used.
   - **headers** *PropTypes.object* (optional) maps to key of record. Use to provide custom header text otherwise the key is used
   - **records** *PropTypes.object* key/ value set of data used to populate the table
+  - **multiSelectColumnName** *PropTypes.string* the value of this column should be a unique string, used to keep track of selected rows.
   - **recordInclusion** *PropTypes.object* (optional) maps to key of record, used to limit what is displayed
   - **onClick** *PropTypes.function* (optional) used to take action on clicking, supplies row index, row data and cell data. When defined, a hover effect is applied to the row.
   - **orderBy** *PropTypes.shape* (optional)
@@ -293,7 +278,7 @@ describe('DataTable', function () {
     - **direction** *PropTypes.oneOf* (optional) 'asc' or 'desc'
     - **formatter** *PropTypes.oneOf* (optional) 'date' specify a way to format column data for sorting
     - **getSortValue** *PropTypes.func* (optional) a function that takes column data and returns a value to be used for sorting, needed for non-primitive data types, like React Components.
-  - **selectedRows** *PropTypes.arrayOf(PropTypes.number)* select rows based on index
+  - **selectedRows** *PropTypes.arrayOf(PropTypes.string)* an array of *multiSelectColumnName* values, used to identify rows.
   - **returnAllRecordsOnClick** *PropTypes.bool* (optional) returns all records for a row in the onClick argument regardless of record inclusion option
   - **filterRecords**  *PropTypes.object* key/ value set of data to filter the records against. If multiple values are supplied, it's considered an OR not an AND
   `);

--- a/tests/DataTable.test.jsx
+++ b/tests/DataTable.test.jsx
@@ -71,19 +71,7 @@ const mockHandleClick = jest.fn();
 const getSortValue = value => (value.props ? value.props.children : value);
 const renderTable = (props) => {
   tableComponent = ReactTestUtils.renderIntoDocument(
-    <DataTable
-      columns={props.columns}
-      headers={props.headers}
-      orderBy={props.orderBy}
-      onClick={props.onClick}
-      onChange={props.onChange}
-      filterRecords={props.filterRecords}
-      multiSelectable={props.multiSelectable}
-      records={props.records}
-      recordInclusion={props.recordInclusion}
-      returnAllRecordsOnClick={props.returnAllRecordsOnClick}
-      selectedRows={props.selectedRows}
-    />,
+    <DataTable {...props} />,
   );
   tableNode = ReactDOM.findDOMNode(tableComponent);
   tHead = tableNode.getElementsByTagName('thead')[0];
@@ -174,8 +162,9 @@ describe('Table', () => {
 
   it('Renders a Table with the first row selected', () => {
     renderTable({
+      multiSelectColumnName: 'name',
       records,
-      selectedRows: [0],
+      selectedRows: [records[0].name],
     });
     expect(row(0).classList.contains('sui-selected')).toBe(true);
   });
@@ -195,7 +184,6 @@ describe('Table', () => {
       records,
     });
     ReactTestUtils.Simulate.mouseOver(row(1));
-
     expect(row(1).style.background).toBe('');
   });
 
@@ -375,7 +363,7 @@ describe('Table', () => {
     renderTable({
       headers,
       records,
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
     });
     expect(cell(0, 0).getElementsByTagName('input').length).toBe(1);
   });
@@ -385,12 +373,11 @@ describe('Table', () => {
     renderTable({
       headers,
       records,
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
       onChange: mockHandleChange,
     });
     const checkBoxNode = tableComponent.checkBoxRefs[2].inputRef;
-    const result = [];
-    result[2] = records[2];
+    const result = [records[2].name];
     ReactTestUtils.Simulate.click(checkBoxNode);
     expect(mockHandleChange).toBeCalledWith(result);
   });
@@ -399,12 +386,12 @@ describe('Table', () => {
     renderTable({
       headers,
       records,
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
       onChange: mockHandleChange,
     });
     const checkBoxNode = tableComponent.checkBoxHeaderRef.inputRef;
     ReactTestUtils.Simulate.click(checkBoxNode);
-    expect(mockHandleChange).toBeCalledWith(records);
+    expect(mockHandleChange).toBeCalledWith(records.map(record => record.name));
   });
 
   it('returns a change event when clicking anywhere within the select all checkbox th cell', () => {
@@ -412,12 +399,12 @@ describe('Table', () => {
     renderTable({
       headers,
       records,
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
       onChange: mockHandleChange,
     });
     const selectAllTHNode = headerElement(0);
     ReactTestUtils.Simulate.click(selectAllTHNode);
-    expect(mockHandleChange).toBeCalledWith(records);
+    expect(mockHandleChange).toBeCalledWith(records.map(record => record.name));
   });
 
   it('returns a change event when filtering segments and select all is triggered', () => {
@@ -425,7 +412,7 @@ describe('Table', () => {
     renderTable({
       headers,
       records,
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
       onChange: mockHandleChange,
       filterRecords: [{ status: 'Inactive' }],
     });
@@ -434,7 +421,7 @@ describe('Table', () => {
     expect(rows().length).toBe(2);
     expect(cell(0, 1).textContent).toBe('Frank');
     expect(cell(1, 1).textContent).toBe('Jose');
-    expect(mockHandleChange).toBeCalledWith([records[1], records[3]]);
+    expect(mockHandleChange).toBeCalledWith([records[1].name, records[3].name]);
   });
 
   it('selects a row when clicking anywhere within the checkbox cell', () => {
@@ -442,11 +429,10 @@ describe('Table', () => {
     renderTable({
       records,
       returnAllRecordsOnClick: true,
-      multiSelectable: true,
+      multiSelectColumnName: 'age',
       onChange: mockHandleChange,
     });
-    const result = [];
-    result[0] = records[0];
+    const result = [records[0].age];
 
     ReactTestUtils.Simulate.click(cell(0, 0));
     expect(mockHandleChange).toBeCalledWith(result);
@@ -466,7 +452,7 @@ describe('Table', () => {
       headers,
       records,
       filterRecords: [{ age: 125 }],
-      multiSelectable: true,
+      multiSelectColumnName: 'name',
     });
     expect(cell(0, 0).colSpan).toEqual('4');
   });
@@ -577,7 +563,7 @@ describe('Table', () => {
       orderBy: {
         column: 'date',
         direction: 'asc',
-        format: 'date',
+        formatter: 'date',
       },
     });
     expect(cell(0, 0).textContent).toBe('2015/12/05 15:06');


### PR DESCRIPTION
Selected rows are now identified by a column, multiSelectable is no longer used.

multiSelectable is no longer used to display checkboxes, multiSelectColumnName is now used for that
purpose.