### PR TITLE
fix(Polyfill-Node.remove): polyfill for the Node.remove() method in Internet Explorer 9 and higher - commonjs

### DIFF
--- a/src/Sprinkles.jsx
+++ b/src/Sprinkles.jsx
@@ -1,3 +1,5 @@
+import './shared/removePolyfill';
+
 export Alert from './components/Alert';
 export Breadcrumbs from './components/Breadcrumbs';
 export BulletedList from './components/BulletedList';


### PR DESCRIPTION
polyfill for the Node.remove() method in Internet Explorer 9 and higher, this time added to the
commonjs build