### PR TITLE
fix(Component-DataTable): DataTable onClick defaults to null, prevent…

### DIFF
--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -44,7 +44,7 @@ export default class DataTable extends Base {
   static defaultProps = {
     noRecordsText: 'No records found.',
     multiselectRowKey: '',
-    onClick: () => {},
+    onClick: null,
     onChange: () => {},
     onHeaderClick: () => {},
     records: [],


### PR DESCRIPTION
…ing hover

Expected behavior for DataTable is that hover is optional, currently it is always on, due to default
blank function for DataTable onClick. This is fixed by defaulting onClick to null