### PR TITLE
fix(All-Components): Move react packages to dev dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
       "max-len": ["error", {
         "code": 150,
         "ignoreStrings": true
-      }],
+      }]
     },
     "globals": {
       "before": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sprinkles-ui",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {
@@ -5737,8 +5737,9 @@
     },
     "react": {
       "version": "15.6.1",
-      "resolved": "http://npm.thebrighttag.com/react/-/react-15.6.1.tgz",
-      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98="
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
+      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "dev": true
     },
     "react-addons-test-utils": {
       "version": "15.6.0",
@@ -5754,8 +5755,9 @@
     },
     "react-dom": {
       "version": "15.6.1",
-      "resolved": "http://npm.thebrighttag.com/react-dom/-/react-dom-15.6.1.tgz",
-      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA="
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "dev": true
     },
     "react-html-attributes": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "glamorous": "^3.23.2",
     "immutable": "^3.8.1",
     "prop-types": "^15.5.10",
-    "react": "^15.3.1",
-    "react-dom": "^15.3.1",
     "react-router": "^3.0.0",
     "react-style-proptype": "^3.0.0",
     "reactcss": "^1.0.7",
@@ -54,11 +52,17 @@
     "jest-cli": "^15.1.1",
     "lorem-ipsum": "^1.0.3",
     "nodemon": "^1.10.2",
+    "react": "^15.6.1",
     "react-addons-test-utils": "^15.3.1",
+    "react-dom": "^15.6.1",
     "standard-version": "^3.0.0",
     "test-exclude": "^3.3.0",
     "ui-harness": "3.19.0",
     "webpack": "^1.13.2"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Move react packages to dev dependencies. Having React as a dependency causes issues with apps using
different version of React, and it's not necessary. This should improve the size of Sprinkles-ui.

49