### PR TITLE
fix(SearchInput): Assigning directly to this.state is deprecated in cwrp

### DIFF
--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -60,10 +60,10 @@ export default class SearchInput extends TextInput {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.state = {
+    this.setState({
       combinedSearchSettings: Object.assign({},
         nextProps.searchSettings, this.defaultSearchSettings),
-    };
+    });
     this.setupFuse(nextProps);
   }
 


### PR DESCRIPTION
fix for React warning: Assigning directly to this.state is deprecated in cwrp, Use setState instead.