### PR TITLE
feat(Component-DataTable): Add multiselect with shift and click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sprinkles-ui",
-  "version": "1.8.11",
+  "version": "1.8.13",
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -58,6 +58,7 @@ export default class DataTable extends Base {
     this.state = {
       hoveredRow: null,
       isRowHovering: false,
+      lastChecked: null,
     };
   }
 
@@ -178,8 +179,24 @@ export default class DataTable extends Base {
     this.props.onChange(ids);
   }
 
-  handleRowSelect(id) {
-    this.props.onChange([id]);
+  handleRowSelect(id, event) {
+    let range = [id];
+
+    if (event.shiftKey) {
+      const currentRecords = this.processRecords().map(item => item.guid);
+      const lastSelectedIdx = currentRecords.indexOf(this.state.lastChecked);
+      const currentSelectedIdx = currentRecords.indexOf(id);
+      const selectedRows = [...this.props.selectedRows, id];
+
+      range = currentRecords
+        .slice(
+          Math.min(lastSelectedIdx, currentSelectedIdx),
+          Math.max(lastSelectedIdx, currentSelectedIdx) + 1,
+        )
+        .filter(item => selectedRows.indexOf(item) === -1);
+    }
+    this.props.onChange(range);
+    this.setState({ lastChecked: id });
   }
 
   renderHeaderItem() {

--- a/tests/DataTable.test.jsx
+++ b/tests/DataTable.test.jsx
@@ -437,6 +437,20 @@ describe('Table', () => {
     expect(mockHandleChange).toBeCalledWith(result);
   });
 
+  it('keeps track of the last clicked row', () => {
+    renderTable({
+      records,
+      returnAllRecordsOnClick: true,
+      multiselectRowKey: 'age',
+    });
+    const rowNumber = 1;
+    const result = records[rowNumber].age;
+
+    expect(tableComponent.state.lastChecked).toBe(null);
+    ReactTestUtils.Simulate.click(cell(rowNumber, 0));
+    expect(tableComponent.state.lastChecked).toBe(result);
+  });
+
   it('generates colSpan for no results', () => {
     renderTable({
       headers,


### PR DESCRIPTION
The DataTable component now allows selecting multiple rows by holding shift and then click, similar
to how Gmail works. 